### PR TITLE
feat: check if string is utf8 string

### DIFF
--- a/test/rulesql_tests.erl
+++ b/test/rulesql_tests.erl
@@ -23,6 +23,16 @@ utf8_test_() ->
         rulesql:parsetree(<<"SELECT * FROM \"测试专用topic\""/utf8>>))
     ].
 
+empty_test_() ->
+    [
+      ?_assertMatch(
+        {parse_error, invalid_string},
+        rulesql:parsetree(<<"">>)),
+     ?_assertMatch(
+        {parse_error, invalid_string},
+        rulesql:parsetree(<<"\r\n  \r\n">>))
+    ].
+
 select_test_() ->
     [
         %% basic select

--- a/test/rulesql_tests.erl
+++ b/test/rulesql_tests.erl
@@ -10,6 +10,19 @@
 keyword_1_test() ->
     [?assert(rulesql:is_reserved(Key)) || Key <- ?RESERVED_KEYS].
 
+utf8_test_() ->
+    [
+      ?_assertMatch(
+        {parse_error, {invalid_utf8, _}},
+        rulesql:parsetree(<<"SELECT x FROM \"测试专用topic\"">>)),
+      ?_assertMatch(
+        {ok,{select,
+          [{fields,['*']},
+            {from,[<<"测试专用topic"/utf8>>]},
+            {where,{}}]}},
+        rulesql:parsetree(<<"SELECT * FROM \"测试专用topic\""/utf8>>))
+    ].
+
 select_test_() ->
     [
         %% basic select


### PR DESCRIPTION
```erlang
% 1. Define a invalid utf8 binary
1> SQL = <<"select * from \"测试专用topic\"">>.

% 2. check if is utf8 with unicode:characters_to_list/1 and characters_to_binary/1
2> unicode:characters_to_list(SQL).
{error,"select * from \"K",<<213,19,40,116,111,112,105,99,34>>}
3 > unicode:characters_to_binary(SQL).
{error,<<"select * from \"K">>,<<213,19,40,116,111,112,105,99,34>>}

% 4. It's valid after re:replace transform ! so we need check before re:replace.
4> C = unicode:characters_to_list(re:replace(SQL, "(^[ \r\n]+)|([ \r\n]+$)", "",[global, {return, list}])).
[115,101,108,101,99,116,32,42,32,102,114,111,109,32,34,75,213,19,40,116,111,112,105,99,34]
5> io:format("~ts~n",[C]).
select * from "KÕ^S(topic"
ok
```
It's part of https://github.com/emqx/emqx/issues/10377